### PR TITLE
Fix missing type hinting in PHPDoc comments

### DIFF
--- a/src/AfterShip/Core/Request.php
+++ b/src/AfterShip/Core/Request.php
@@ -48,6 +48,8 @@ class Request
 			case "DELETE":
 				$request = $this->_client->delete($this->_api_url . '/' . $this->_api_version . '/' . $url, $headers, json_encode($data));
 				break;
+            default:
+                throw new \Exception("Method $request_type is currently not supported.");
 		}
 
 		try {

--- a/src/AfterShip/Core/Request.php
+++ b/src/AfterShip/Core/Request.php
@@ -28,7 +28,7 @@ class Request
 		}
 	}
 
-	protected function send($url, $request_type, $data = array())
+	protected function send($url, $request_type, array $data = array())
 	{
 		$headers = array(
 			'aftership-api-key' => $this->_api_key,

--- a/src/AfterShip/Couriers.php
+++ b/src/AfterShip/Couriers.php
@@ -6,11 +6,15 @@ use AfterShip\Core\Request;
 
 class Couriers extends Request
 {
-	/**
-	 * The Couriers Constructor.
-	 * @param $api_key The AfterShip API Key.
-	 * @param array $guzzle_plugins Guzzle Plugins
-	 */
+
+    /**
+     * The Couriers Constructor.
+     *
+     * @param string $api_key The AfterShip API Key.
+     * @param array $guzzle_plugins Guzzle Plugins
+     *
+     * @throws \Exception
+     */
 	public function __construct($api_key, $guzzle_plugins = array())
     {
         if (empty($api_key))
@@ -51,7 +55,7 @@ class Couriers extends Request
 	 * Return a list of matched couriers of a tracking based on the tracking number format. User can limit number of
 	 * matched couriers and change courier priority at courier settings. Or, passing the parameter `slugs` to detect.
 	 * https://www.aftership.com/docs/api/4/couriers/post-couriers-detect
-	 * @param $tracking_number The tracking number which is provider by tracking provider
+	 * @param string $tracking_number The tracking number which is provider by tracking provider
 	 * @param array $params The optional parameters
 	 * @return array Response Body
 	 * @throws \Exception

--- a/src/AfterShip/Couriers.php
+++ b/src/AfterShip/Couriers.php
@@ -15,7 +15,7 @@ class Couriers extends Request
      *
      * @throws \Exception
      */
-	public function __construct($api_key, $guzzle_plugins = array())
+	public function __construct($api_key, array $guzzle_plugins = array())
     {
         if (empty($api_key))
             throw new \Exception('API Key is missing');

--- a/src/AfterShip/LastCheckPoint.php
+++ b/src/AfterShip/LastCheckPoint.php
@@ -20,7 +20,7 @@ class LastCheckPoint extends Request
      *
      * @throws \Exception
      */
-	public function __construct ($api_key, $guzzle_plugins = array())
+	public function __construct ($api_key, array $guzzle_plugins = array())
     {
         if (empty($api_key)) {
             throw new \Exception('API Key is missing');

--- a/src/AfterShip/LastCheckPoint.php
+++ b/src/AfterShip/LastCheckPoint.php
@@ -11,11 +11,15 @@ use AfterShip\Core\Request;
  */
 class LastCheckPoint extends Request
 {
-	/**
-	 * The LastCheckPoint constructor.
-	 * @param $api_key The AfterShip API Key.
-	 * @param array $guzzle_plugins Guzzle Plugins
-	 */
+
+    /**
+     * The LastCheckPoint constructor.
+     *
+     * @param string $api_key The AfterShip API Key.
+     * @param array $guzzle_plugins Guzzle Plugins
+     *
+     * @throws \Exception
+     */
 	public function __construct ($api_key, $guzzle_plugins = array())
     {
         if (empty($api_key)) {
@@ -34,8 +38,8 @@ class LastCheckPoint extends Request
 	/**
 	 * Return the tracking information of the last checkpoint of a single tracking.
 	 * https://www.aftership.com/docs/api/4/last_checkpoint/get-last_checkpoint-slug-tracking_number
-	 * @param $slug The slug of the tracking provider
-	 * @param $tracking_number The tracking number which is provider by tracking provider
+	 * @param string $slug The slug of the tracking provider
+	 * @param string $tracking_number The tracking number which is provider by tracking provider
 	 * @param array $params The optional parameters
 	 * @return array Response body
 	 * @throws \Exception
@@ -56,7 +60,7 @@ class LastCheckPoint extends Request
 	/**
 	 * Return the tracking information of the last checkpoint of a single tracking.
 	 * https://www.aftership.com/docs/api/4/last_checkpoint/get-last_checkpoint-slug-tracking_number
-	 * @param $id The tracking ID which is provided by AfterShip
+	 * @param string $id The tracking ID which is provided by AfterShip
 	 * @param array $params The optional parameters
 	 * @return array Response body
 	 * @throws \Exception

--- a/src/AfterShip/Trackings.php
+++ b/src/AfterShip/Trackings.php
@@ -6,11 +6,15 @@ use AfterShip\Core\Request;
 
 class Trackings extends Request
 {
-	/**
-	 * The Trackings constructor.
-	 * @param $api_key The AfterShip API Key.
-	 * @param array $guzzle_plugins Guzzle Plugins
-	 */
+
+    /**
+     * The Trackings constructor.
+     *
+     * @param string $api_key The AfterShip API Key.
+     * @param array $guzzle_plugins Guzzle Plugins
+     *
+     * @throws \Exception
+     */
 	public function __construct($api_key, $guzzle_plugins = array())
 	{
 		if (empty($api_key)) {
@@ -29,7 +33,7 @@ class Trackings extends Request
 	/**
 	 * Create a tracking.
 	 * https://www.aftership.com/docs/api/4/trackings/post-trackings
-	 * @param $tracking_number The tracking number which is provider by tracking provider
+	 * @param string $tracking_number The tracking number which is provider by tracking provider
 	 * @param array $params The optional parameters
 	 * @return array Reponse Body
 	 * @throws \Exception
@@ -60,8 +64,8 @@ class Trackings extends Request
 	/**
 	 * Delete a tracking number.
 	 * https://www.aftership.com/docs/api/4/trackings/delete-trackings
-	 * @param $slug The slug of the tracking provider
-	 * @param $tracking_number The tracking number which is provider by tracking provider
+	 * @param string $slug The slug of the tracking provider
+	 * @param string $tracking_number The tracking number which is provider by tracking provider
 	 * @return array Response body
 	 * @throws \Exception
 	 */
@@ -81,7 +85,7 @@ class Trackings extends Request
 	/**
 	 * Delete a tracking number.
 	 * https://www.aftership.com/docs/api/4/trackings/delete-trackings
-	 * @param $id The tracking ID which is provided by AfterShip
+	 * @param string $id The tracking ID which is provided by AfterShip
 	 * @return array Response body
 	 * @throws \Exception
 	 */
@@ -106,8 +110,8 @@ class Trackings extends Request
 	/**
 	 * Get tracking results of a single tracking.
 	 * https://www.aftership.com/docs/api/4/trackings/get-trackings-slug-tracking_number
-	 * @param $slug The slug of the tracking provider
-	 * @param $tracking_number The tracking number which is provider by tracking provider
+	 * @param string $slug The slug of the tracking provider
+	 * @param string $tracking_number The tracking number which is provider by tracking provider
 	 * @param array $params The optional parameters
 	 * @return array Response body
 	 * @throws \Exception
@@ -128,7 +132,7 @@ class Trackings extends Request
 	/**
 	 * Get tracking results of a single tracking.
 	 * https://www.aftership.com/docs/api/4/trackings/get-trackings-slug-tracking_number
-	 * @param $id The tracking ID which is provided by AfterShip
+	 * @param string $id The tracking ID which is provided by AfterShip
 	 * @param array $params The optional parameters
 	 * @return array Response body
 	 * @throws \Exception
@@ -144,8 +148,8 @@ class Trackings extends Request
 	/**
 	 * Update a tracking.
 	 * https://www.aftership.com/docs/api/4/trackings/put-trackings-slug-tracking_number
-	 * @param $slug The slug of the tracking provider
-	 * @param $tracking_number The tracking number which is provider by tracking provider
+	 * @param string $slug The slug of the tracking provider
+	 * @param string $tracking_number The tracking number which is provider by tracking provider
 	 * @param array $params The optional parameters
 	 * @return array Response body
 	 * @throws \Exception
@@ -166,7 +170,7 @@ class Trackings extends Request
 	/**
 	 * Update a tracking.
 	 * https://www.aftership.com/docs/api/4/trackings/put-trackings-slug-tracking_number
-	 * @param $id The tracking ID which is provided by AfterShip
+	 * @param string $id The tracking ID which is provided by AfterShip
 	 * @param array $params The optional parameters
 	 * @return array Response body
 	 * @throws \Exception
@@ -183,8 +187,8 @@ class Trackings extends Request
 	/**
 	 * Retrack an expired tracking once.
 	 * https://www.aftership.com/docs/api/4/trackings/post-trackings-slug-tracking_number-retrack
-	 * @param $slug The slug of tracking provider
-	 * @param $tracking_number The tracking number which is provider by tracking provider
+	 * @param string $slug The slug of tracking provider
+	 * @param string $tracking_number The tracking number which is provider by tracking provider
 	 * @return array Response body
 	 * @throws \Exception
 	 */
@@ -204,7 +208,7 @@ class Trackings extends Request
 	/**
 	 * Retrack an expired tracking once.
 	 * https://www.aftership.com/docs/api/4/trackings/post-trackings-slug-tracking_number-retrack
-	 * @param $id The tracking ID which is provided by AfterShip
+	 * @param string $id The tracking ID which is provided by AfterShip
 	 * @return array Response body
 	 * @throws \Exception
 	 */


### PR DESCRIPTION
Fix the PHPDoc comments to include type hinting which was missing. Also included some exceptions that were missing from PHPDoc blocks. 